### PR TITLE
Added relative path for the use of internal classes

### DIFF
--- a/Imgur.php
+++ b/Imgur.php
@@ -8,7 +8,7 @@
  */
 
 spl_autoload_register(function ($cname) {
-    require_once("classes/" . $cname . ".php");
+    require_once(__DIR__."/classes/" . $cname . ".php");
     throw new Exception("Class " . $cname . " failed to load. Please verify that you uploaded the files correctly.");
 });
 


### PR DESCRIPTION
Otherwise, this library doesn't work if, for example, I have `include/Imgur.php` included from `index.php`. With the new syntax, relative path to this file rather than the top file will be used.